### PR TITLE
Removed die and dump (dd()) from paymentCancelled method

### DIFF
--- a/src/Rave.php
+++ b/src/Rave.php
@@ -184,7 +184,6 @@ class Rave {
         if (request()->cancelled) {
             $cancelledResponse = '{"status": "cancelled" , "message": "Customer cancelled the transaction", "data":{ "status": "cancelled", "txRef" :"' . $this->txref . '"}}';
             $resp = json_decode($cancelledResponse);
-            dd($resp);
             return $resp;
         } else {
             return $data;


### PR DESCRIPTION
The script always ended and immediately dumped its json response at each failed payment transaction instead of returning a json resp. 

This could possible be a slight oversight. 