### PR TITLE
Add country code to request while creating subaccount

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@
 - [Ifunanya Ikemma](https://github.com/Iphytech)
 - [Abhishek Prakash](https://github.com/abhishek6262)
 - [Wallace Myem Aboiyar](https://github.com/wallacemyem)
+- [Chigozie Ekwonu](https://github.com/chygoz2)
 
 ## Contributing
 Please feel free to fork this package and contribute by submitting a pull request to enhance the functionalities. I will appreciate that a lot. Also please add your name to the credits.

--- a/src/Rave.php
+++ b/src/Rave.php
@@ -895,7 +895,8 @@ class Rave
             'meta' => $meta,
             'seckey' => $this->secretKey,
             'split_type' => $this->request->split_type,
-            'split_value' => $this->request->split_value
+            'split_value' => $this->request->split_value,
+            'country' => $this->request->country
         ];
 
         // Make request to endpoint using unirest.


### PR DESCRIPTION
This adds country code to the request body sent to rave api while creating subaccounts as this is now a required field.