### PR TITLE
Callback Document Correction

### DIFF
--- a/docs/getting-started/payment-implementation.md
+++ b/docs/getting-started/payment-implementation.md
@@ -107,12 +107,14 @@ class FlutterwaveController extends Controller
 
         dd($data);
         }
+        elseif ($status ==  'cancelled'){
+            //Put desired action/code after transaction has been cancelled here
+        }
         else{
-            //Pass redirect for cancelled transaction here
+            //Put desired action/code after transaction has failed here
         }
         // Get the transaction from your DB using the transaction reference (txref)
         // Check if you have previously given value for the transaction. If you have, redirect to your successpage else, continue
-        // Confirm that the $data['data']['status'] is 'successful'
         // Confirm that the currency on your db transaction is equal to the returned currency
         // Confirm that the db transaction amount is equal to the returned amount
         // Update the db transaction record (including parameters that didn't exist before the transaction is completed. for audit purpose)

--- a/docs/getting-started/payment-implementation.md
+++ b/docs/getting-started/payment-implementation.md
@@ -99,7 +99,7 @@ class FlutterwaveController extends Controller
         
         $status = request()->status;
 
-        //if payments is successful
+        //if payment is successful
         if ($status ==  'successful') {
         
         $transactionID = Flutterwave::getTransactionIDFromCallback();

--- a/docs/getting-started/payment-implementation.md
+++ b/docs/getting-started/payment-implementation.md
@@ -96,11 +96,20 @@ class FlutterwaveController extends Controller
      */
     public function callback()
     {
+        
+        $status = request()->status;
 
+        //if payments is successful
+        if ( $status ==  'successful') {
+        
         $transactionID = Flutterwave::getTransactionIDFromCallback();
         $data = Flutterwave::verifyTransaction($transactionID);
 
         dd($data);
+        else{
+
+            //Pass redirect for cancelled transaction here
+        }
         // Get the transaction from your DB using the transaction reference (txref)
         // Check if you have previously given value for the transaction. If you have, redirect to your successpage else, continue
         // Confirm that the $data['data']['status'] is 'successful'

--- a/docs/getting-started/payment-implementation.md
+++ b/docs/getting-started/payment-implementation.md
@@ -100,14 +100,14 @@ class FlutterwaveController extends Controller
         $status = request()->status;
 
         //if payments is successful
-        if ( $status ==  'successful') {
+        if ($status ==  'successful') {
         
         $transactionID = Flutterwave::getTransactionIDFromCallback();
         $data = Flutterwave::verifyTransaction($transactionID);
 
         dd($data);
+        }
         else{
-
             //Pass redirect for cancelled transaction here
         }
         // Get the transaction from your DB using the transaction reference (txref)


### PR DESCRIPTION
If the transaction is cancelled it throws an error because the transaction id is not being passed when a transaction has been cancelled. Getting the transaction status before doing anything in the callback fixes this.

Below is the screenshot of the error
![image](https://user-images.githubusercontent.com/38886632/119163336-39d14500-ba53-11eb-8688-eaa96ed452d4.png)
