### PR TITLE
All Laravel compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ dist
 .basement
 config.local.js
 basement_dist
+*.code-workspace

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         "Flutterwave",
         "rave",
         "ravepay.co",
-        "laravel 5 to 12"
+        "laravel 5"
     ],
     "license": "MIT",
     "authors": [
@@ -23,12 +23,12 @@
     ],
     "minimum-stability": "stable",
     "require": {
-        "php": "^7.2|^8.0|^8.2|^8.3|^8.4",
+        "php": "^7.2|^8.0|^8.3",
         "illuminate/support": "^5.0|^6.0|^7.0|^8.0|^9.0|^10.0|^11.0|^12.0"
     },
     "require-dev": {
-        "phpunit/phpunit": ">=10.0",
-        "php-coveralls/php-coveralls": ">=2.6.0",
+        "phpunit/phpunit": ">=10",
+        "php-coveralls/php-coveralls": "^2.6.0",
         "mockery/mockery": ">1.2",
         "orchestra/testbench": ">4.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         "Flutterwave",
         "rave",
         "ravepay.co",
-        "laravel 5"
+        "laravel 5 to 12"
     ],
     "license": "MIT",
     "authors": [
@@ -23,12 +23,12 @@
     ],
     "minimum-stability": "stable",
     "require": {
-        "php": "^7.2|^8.0|^8.3",
-        "illuminate/support": "^5.0|^6.0|^7.0|^8.0|^9.0|^10.0|^11.0"
+        "php": "^7.2|^8.0|^8.2|^8.3|^8.4",
+        "illuminate/support": "^5.0|^6.0|^7.0|^8.0|^9.0|^10.0|^11.0|^12.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^10",
-        "php-coveralls/php-coveralls": "^2.6.0",
+        "phpunit/phpunit": ">=10.0",
+        "php-coveralls/php-coveralls": ">=2.6.0",
         "mockery/mockery": ">1.2",
         "orchestra/testbench": ">4.0"
     },

--- a/laravelrave.code-workspace
+++ b/laravelrave.code-workspace
@@ -1,0 +1,8 @@
+{
+	"folders": [
+		{
+			"path": "."
+		}
+	],
+	"settings": {}
+}


### PR DESCRIPTION
This update makes kingflamez/laravelrave compatible with **Laravel 5 through 12**.  

**Changes:**
- Updated `illuminate/support` requirement to include Laravel 12.
- Expanded PHP support to `^7.2|^8.0|^8.3`.
- No functional changes to the package code.

**Benefits:**
- Works with older and the latest Laravel versions.
- Prevents installation conflicts in modern Laravel projects.
